### PR TITLE
fix: Corrige validação de campos obrigatórios no checkout

### DIFF
--- a/app/includes/processar_pedido.php
+++ b/app/includes/processar_pedido.php
@@ -19,18 +19,19 @@ $metodo_pagamento = $_POST['metodo_pagamento'] ?? 'Não informado';
 $troco_para = !empty($_POST['troco_para']) ? $_POST['troco_para'] : null;
 $observacoes = trim($_POST['observacoes']) ?? null;
 
-// Valida os dados de acordo com o tipo de entrega
 if ($tipo_entrega == 'delivery') {
-    $endereco = trim($_POST['endereco_entrega']);
-    $telefone = trim($_POST['telefone_contato']);
-    if (empty($endereco) || empty($telefone)) {
+    $endereco_entrega = trim($_POST['endereco_entrega']);
+    $telefone_contato = trim($_POST['telefone_contato']);
+    if (empty($endereco_entrega) || empty($telefone_contato)) {
         header('Location: ' . BASE_URL . '/checkout.php?status=erro_dados');
         exit();
     }
 } else {
-    $endereco = 'Retirada no Local';
-    $telefone = trim($_POST['telefone_retirada']);
-    if (empty($telefone)) {
+    // CORREÇÃO PRINCIPAL NO BACK-END:
+    // Define um valor padrão para o endereço e pega o telefone do campo correto.
+    $endereco_entrega = 'Retirada no Local';
+    $telefone_contato = trim($_POST['telefone_retirada']);
+    if (empty($telefone_contato)) {
         header('Location: ' . BASE_URL . '/checkout.php?status=erro_dados');
         exit();
     }
@@ -66,8 +67,11 @@ try {
     // 3. --- SQL ATUALIZADO PARA INCLUIR OS NOVOS CAMPOS ---
     $sql_pedido = "INSERT INTO pedidos (login_id, valor_total, endereco_entrega, telefone_contato, status, tipo_entrega, metodo_pagamento, troco_para, observacoes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
     $stmt_pedido = $pdo->prepare($sql_pedido);
-    $stmt_pedido->execute([$id_usuario, $valor_total, $endereco, $telefone, 'Pendente', $tipo_entrega, $metodo_pagamento, $troco_para, $observacoes]);
-    
+    // A linha abaixo é a importante. Verifique se as variáveis estão corretas.
+    // ...
+    $stmt_pedido->execute([$id_usuario, $valor_total, $endereco_entrega, $telefone_contato, 'Pendente', $tipo_entrega, $metodo_pagamento, $troco_para, $observacoes]);
+    // ...
+
     $id_pedido = $pdo->lastInsertId();
 
     // 4. Insere os itens na tabela 'pedido_itens' (código existente)
@@ -93,7 +97,6 @@ try {
 
     header("Location: " . BASE_URL . "/pedido_sucesso.php");
     exit();
-
 } catch (Exception $e) {
     $pdo->rollBack();
     error_log("Erro ao processar pedido: " . $e->getMessage());

--- a/public/checkout.php
+++ b/public/checkout.php
@@ -24,7 +24,6 @@ try {
     $stmt_usuario = $pdo->prepare("SELECT endereco, telefone FROM login WHERE id = ?");
     $stmt_usuario->execute([$id_usuario]);
     $dados_usuario = $stmt_usuario->fetch(PDO::FETCH_ASSOC);
-
 } catch (PDOException $e) {
     die("Erro ao buscar informações: " . $e->getMessage());
 }
@@ -37,7 +36,7 @@ try {
         <div class="form-box checkout-form-box">
             <form id="checkout-form" action="<?php echo BASE_URL; ?>/actions/processar_pedido.php" method="POST">
                 <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
-                
+
                 <div id="step-1" class="checkout-step active">
                     <div class="checkout-section">
                         <h2>1. Como quer receber?</h2>
@@ -60,7 +59,7 @@ try {
                         <h2>2. Informações de Entrega</h2>
                         <label for="endereco">Endereço Completo</label>
                         <textarea name="endereco_entrega" id="endereco" required placeholder="Ex: Rua das Flores, 123, Bairro..."><?php echo htmlspecialchars($dados_usuario['endereco'] ?? ''); ?></textarea>
-                        
+
                         <label for="telefone">Telefone para Contato</label>
                         <input type="text" name="telefone_contato" id="telefone" required placeholder="(11) 99999-8888" value="<?php echo htmlspecialchars($dados_usuario['telefone'] ?? ''); ?>">
                     </div>
@@ -68,7 +67,7 @@ try {
                         <h2>2. Informações para Retirada</h2>
                         <p>Nosso endereço é: <strong>Rua Fictícia, 100 - Centro</strong>.</p>
                         <label for="telefone_retirada">Seu Telefone para Contato</label>
-                        <input type="text" name="telefone_retirada" id="telefone_retirada" placeholder="(11) 99999-8888" value="<?php echo htmlspecialchars($dados_usuario['telefone'] ?? ''); ?>">
+                        <input type="text" name="telefone_retirada" id="telefone_retirada" placeholder="(11) 99999-8888" value="<?php echo htmlspecialchars($dados_usuario['telefone'] ?? ''); ?>" required>
                     </div>
                     <div class="step-navigation">
                         <button type="button" class="btn-prev">Voltar</button>
@@ -81,9 +80,15 @@ try {
                         <h2>3. Pagamento</h2>
                         <p>O pagamento é realizado na entrega ou retirada.</p>
                         <div class="option-group">
-                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Dinheiro" checked> <div class="option-box-content"><strong>Dinheiro</strong></div></label>
-                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Cartao"> <div class="option-box-content"><strong>Cartão</strong></div></label>
-                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Pix"> <div class="option-box-content"><strong>Pix</strong></div></label>
+                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Dinheiro" checked>
+                                <div class="option-box-content"><strong>Dinheiro</strong></div>
+                            </label>
+                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Cartao">
+                                <div class="option-box-content"><strong>Cartão</strong></div>
+                            </label>
+                            <label class="option-box"><input type="radio" name="metodo_pagamento" value="Pix">
+                                <div class="option-box-content"><strong>Pix</strong></div>
+                            </label>
                         </div>
                         <div id="campo-troco" style="margin-top: 15px;">
                             <label for="troco_para">Precisa de troco?</label>
@@ -103,20 +108,20 @@ try {
         <div class="resumo-pedido">
             <h3>Resumo do Pedido</h3>
             <ul>
-            <?php foreach($itens_carrinho as $item): 
-                $preco_item = $item['preco_produto'];
-                $personalizacao = json_decode($item['personalizacao'], true);
-                if (!empty($personalizacao)) {
-                    foreach ($personalizacao as $opcional) $preco_item += $opcional['preco'];
-                }
-                $subtotal_item = $preco_item * $item['quantidade'];
-                $total_carrinho += $subtotal_item;
-            ?>
-                <li>
-                    <span><?php echo $item['quantidade']; ?>x <?php echo htmlspecialchars($item['nome_produto']); ?></span>
-                    <span>R$ <?php echo number_format($subtotal_item, 2, ',', '.'); ?></span>
-                </li>
-            <?php endforeach; ?>
+                <?php foreach ($itens_carrinho as $item):
+                    $preco_item = $item['preco_produto'];
+                    $personalizacao = json_decode($item['personalizacao'], true);
+                    if (!empty($personalizacao)) {
+                        foreach ($personalizacao as $opcional) $preco_item += $opcional['preco'];
+                    }
+                    $subtotal_item = $preco_item * $item['quantidade'];
+                    $total_carrinho += $subtotal_item;
+                ?>
+                    <li>
+                        <span><?php echo $item['quantidade']; ?>x <?php echo htmlspecialchars($item['nome_produto']); ?></span>
+                        <span>R$ <?php echo number_format($subtotal_item, 2, ',', '.'); ?></span>
+                    </li>
+                <?php endforeach; ?>
             </ul>
             <hr>
             <div class="total-resumo"><strong>Total:</strong> <strong>R$ <?php echo number_format($total_carrinho, 2, ',', '.'); ?></strong></div>
@@ -124,71 +129,105 @@ try {
     </div>
 </div>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    let currentStep = 1;
-    const steps = document.querySelectorAll('.checkout-step');
-    const form = document.getElementById('checkout-form');
+    document.addEventListener('DOMContentLoaded', function() {
+        let currentStep = 1;
+        const steps = document.querySelectorAll('.checkout-step');
+        const form = document.getElementById('checkout-form');
 
-    function showStep(stepNumber) {
-        steps.forEach(step => step.style.display = 'none');
-        document.getElementById(`step-${stepNumber}`).style.display = 'block';
-        currentStep = stepNumber;
-    }
+        function showStep(stepNumber) {
+            steps.forEach(step => step.style.display = 'none');
+            document.getElementById(`step-${stepNumber}`).style.display = 'block';
+            currentStep = stepNumber;
+        }
 
-    form.addEventListener('click', function(e) {
-        if (e.target.classList.contains('btn-next')) {
-            // Validação antes de avançar
-            if (currentStep === 2) {
-                const isDelivery = document.querySelector('input[name="tipo_entrega"]:checked').value === 'delivery';
-                if (isDelivery) {
-                    const endereco = document.getElementById('endereco').value.trim();
-                    const telefone = document.getElementById('telefone').value.trim();
-                    if (endereco === '' || telefone === '') {
-                        alert('Por favor, preencha seu endereço e telefone para continuar.');
-                        return; // Impede o avanço
+        form.addEventListener('click', function(e) {
+            if (e.target.classList.contains('btn-next')) {
+                // --- VALIDAÇÃO CORRIGIDA ANTES DE AVANÇAR ---
+                if (currentStep === 2) {
+                    const tipoEntrega = document.querySelector('input[name="tipo_entrega"]:checked').value;
+
+                    if (tipoEntrega === 'delivery') {
+                        // Validação para entrega
+                        const endereco = document.getElementById('endereco').value.trim();
+                        const telefone = document.getElementById('telefone').value.trim();
+                        if (endereco === '' || telefone === '') {
+                            alert('Por favor, preencha seu endereço e telefone para continuar.');
+                            return; // Impede o avanço
+                        }
+                    } else { // Se for 'retirada'
+                        // Validação para retirada
+                        const telefoneRetirada = document.getElementById('telefone_retirada').value.trim();
+                        if (telefoneRetirada === '') {
+                            alert('Por favor, preencha seu telefone para contato.');
+                            return; // Impede o avanço
+                        }
                     }
                 }
+                if (currentStep < steps.length) {
+                    showStep(currentStep + 1);
+                }
+            } else if (e.target.classList.contains('btn-prev')) {
+                if (currentStep > 1) {
+                    showStep(currentStep - 1);
+                }
             }
-            if (currentStep < steps.length) {
-                showStep(currentStep + 1);
-            }
-        } else if (e.target.classList.contains('btn-prev')) {
-            if (currentStep > 1) {
-                showStep(currentStep - 1);
+        });
+
+        // --- LÓGICA CORRIGIDA PARA ALTERNAR ENTREGA E RETIRADA ---
+        const radiosEntrega = document.querySelectorAll('input[name="tipo_entrega"]');
+        const infoDelivery = document.getElementById('info-delivery');
+        const infoRetirada = document.getElementById('info-retirada');
+
+        // Inputs dos campos que precisam ter o 'required' ativado/desativado
+        const enderecoInput = document.getElementById('endereco');
+        const telefoneDeliveryInput = document.getElementById('telefone');
+        const telefoneRetiradaInput = document.getElementById('telefone_retirada');
+
+        function toggleCamposEntrega() {
+            const isRetirada = document.querySelector('input[name="tipo_entrega"]:checked').value === 'retirada';
+
+            if (isRetirada) {
+                // Mostra campos de retirada e esconde os de entrega
+                infoDelivery.style.display = 'none';
+                infoRetirada.style.display = 'block';
+
+                // Torna o telefone de retirada obrigatório
+                telefoneRetiradaInput.setAttribute('required', '');
+
+                // REMOVE a obrigatoriedade dos campos de entrega
+                enderecoInput.removeAttribute('required');
+                telefoneDeliveryInput.removeAttribute('required');
+            } else {
+                // Mostra campos de entrega e esconde os de retirada
+                infoDelivery.style.display = 'block';
+                infoRetirada.style.display = 'none';
+
+                // Torna os campos de entrega obrigatórios
+                enderecoInput.setAttribute('required', '');
+                telefoneDeliveryInput.setAttribute('required', '');
+
+                // REMOVE a obrigatoriedade do telefone de retirada
+                telefoneRetiradaInput.removeAttribute('required');
             }
         }
+        radiosEntrega.forEach(radio => radio.addEventListener('change', toggleCamposEntrega));
+
+        // Chama a função uma vez no início para garantir que o estado inicial está correto
+        toggleCamposEntrega();
+        // --- LÓGICA PARA O CAMPO DE TROCO ---
+        const radiosPagamento = document.querySelectorAll('input[name="metodo_pagamento"]');
+        const campoTroco = document.getElementById('campo-troco');
+
+        function toggleCampoTroco() {
+            if (document.querySelector('input[name="metodo_pagamento"]:checked').value === 'Dinheiro') {
+                campoTroco.style.display = 'block';
+            } else {
+                campoTroco.style.display = 'none';
+            }
+        }
+        radiosPagamento.forEach(radio => radio.addEventListener('change', toggleCampoTroco));
+        toggleCampoTroco();
     });
-
-    // --- LÓGICA PARA ALTERNAR ENTREGA E RETIRADA ---
-    const radiosEntrega = document.querySelectorAll('input[name="tipo_entrega"]');
-    const infoDelivery = document.getElementById('info-delivery');
-    const infoRetirada = document.getElementById('info-retirada');
-
-    function toggleCamposEntrega() {
-        if (document.querySelector('input[name="tipo_entrega"]:checked').value === 'retirada') {
-            infoDelivery.style.display = 'none';
-            infoRetirada.style.display = 'block';
-        } else {
-            infoDelivery.style.display = 'block';
-            infoRetirada.style.display = 'none';
-        }
-    }
-    radiosEntrega.forEach(radio => radio.addEventListener('change', toggleCamposEntrega));
-    
-    // --- LÓGICA PARA O CAMPO DE TROCO ---
-    const radiosPagamento = document.querySelectorAll('input[name="metodo_pagamento"]');
-    const campoTroco = document.getElementById('campo-troco');
-
-    function toggleCampoTroco() {
-        if (document.querySelector('input[name="metodo_pagamento"]:checked').value === 'Dinheiro') {
-            campoTroco.style.display = 'block';
-        } else {
-            campoTroco.style.display = 'none';
-        }
-    }
-    radiosPagamento.forEach(radio => radio.addEventListener('change', toggleCampoTroco));
-    toggleCampoTroco();
-});
 </script>
 
 <?php require_once __DIR__ . '/../app/templates/footer.php'; ?>


### PR DESCRIPTION
Corrige o bug que impedia a finalização de pedidos para "Retirar no Local".

O problema era causado pelo atributo `required` que permanecia nos campos de delivery mesmo quando estavam escondidos, bloqueando o envio do formulário. A solução foi usar JavaScript para adicionar e remover o atributo `required` dinamicamente, de acordo com a opção de entrega selecionada.